### PR TITLE
Add `Makefile` target and document running on all Python files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ PYPI_SERVER=pypi
 build:
 	@${PYTHON} -m build
 
+.PHONY: extract-todo
+extract-todo:
+	git ls-files '**/*.py' -z | xargs -0 extract-todo | cat -s
+
 .PHONY: test
 test: # Run tests
 	@${PYTHON} -m unittest -b

--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ It prints the filename, line number and the TODO text. Example output:
       LINE 1:       test
       LINE 5:       test 2
 
+### Running on all relevant files in a directory
+
+Note that if you want to run this tool on all the Python files in your
+git-managed project, you could do something like this:
+
+    git ls-files '**/*.py' -z | xargs -0 extract-todo | cat -s
+
+To make this really easy for everyone using your repo, you could add a `Makefile` target that does this automatically:
+
+```Makefile
+.PHONY: extract-todo
+extract-todo:
+	git ls-files '**/*.py' -z | xargs -0 extract-todo | cat -s
+```
+
 ## Author and License
 
 Copyright (C) Jens Wilberg July 2021


### PR DESCRIPTION
This adds a `Makefile` target that extracts all todos in this repo:

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/extract-todo (make-extract-todo)
$ make extract-todo
git ls-files '**/*.py' -z | xargs -0 extract-todo | cat -s

tests/test_filetypes.py
  LINE 76:	test
  LINE 79:	test 2
  LINE 81:	test 3
  LINE 96:	test 2
  LINE 126:	test 2
  LINE 218:	test
  LINE 219:	test 2
```

It also adds a [section in the `README.md`](https://github.com/msabramo/extract-todo/blob/make-extract-todo/README.md#running-on-all-relevant-files-in-a-directory) describing how people can do this in their own projects.