### PR TITLE
Add `--match-regex` flag

### DIFF
--- a/src/extract_todo/__main__.py
+++ b/src/extract_todo/__main__.py
@@ -36,10 +36,11 @@ def main():
             tex-files and Python-files. Currently only 'utf-8' file-encoding is\
             supported.")
     parser.add_argument("files", metavar="file", type=Path, help="Path to file.", nargs='+')
+    parser.add_argument("--match-regex", metavar="match_regex", type=str, help="Regex pattern that todos should match")
     parser.add_argument('-v', '--version', action='version', version='%(prog)s {}'.format(__version__))
     args = parser.parse_args()
     try:
-        todos = [str(Printer(extract_todos(fname))) for fname in args.files]
+        todos = [str(Printer(extract_todos(fname, args.match_regex))) for fname in args.files]
         if todos:
             print('\n'.join(todos))
         else:

--- a/src/extract_todo/extractor.py
+++ b/src/extract_todo/extractor.py
@@ -25,7 +25,7 @@ from typing import List, Tuple
 from .parser import ParserFactory
 
 
-def extract_todos(fpath: Path) -> List[Tuple[Path, int, str]]:
+def extract_todos(fpath: Path, match_regex="") -> List[Tuple[Path, int, str]]:
     """Method for TODO extraction.
 
     Parameters
@@ -44,8 +44,12 @@ def extract_todos(fpath: Path) -> List[Tuple[Path, int, str]]:
     todos = []
     for _, line, text in parser.parse():
         match = re.search(r"TODO[ |\t]*(.*)$", text)
-        if match:
-            todos.append((fpath, line, match.group(1)))
+        if not match:
+            continue
+        if match_regex and not re.search(match_regex, text):
+            continue
+
+        todos.append((fpath, line, match.group(1)))
     return todos
 
 

--- a/tests/test_filetypes.py
+++ b/tests/test_filetypes.py
@@ -40,7 +40,7 @@ class Test(TestCase):
         """Tear down test fixtures, if any."""
         pass
 
-    def extract_todo(self, file: Path, content: str, expected: List[Tuple[Path, int, str]]):
+    def extract_todo(self, file: Path, content: str, expected: List[Tuple[Path, int, str]], match_regex=""):
         """Test 'extract_todos' function.
 
         Parameters
@@ -53,7 +53,7 @@ class Test(TestCase):
             List of expected todos
         """
         self.fs.create_file(file, contents=content)
-        todos = extract_todos(file)
+        todos = extract_todos(file, match_regex=match_regex)
         self.assertListEqual(todos, expected)
 
     def test_latex(self):
@@ -87,6 +87,26 @@ if __name__ == '__main__':
         corr = [(fpath, 1, "test"), (fpath, 4, "test 2"), (fpath, 6, "test 3")]
 
         self.extract_todo(fpath, content, corr)
+
+    def test_py_with_match_regex(self):
+        """Test py-file with match_regex."""
+        content = """\
+# TODO test
+
+def main():
+    print("Hello World")  # TODO test 2
+    print("Hello World again")  # TODO test 2 again
+    print("Hello World!")  # Plain comment
+
+#TODO test 3
+
+if __name__ == '__main__':
+    main()
+"""
+        fpath = Path("test.py")
+        corr = [(fpath, 4, "test 2"), (fpath, 5, "test 2 again")]
+
+        self.extract_todo(fpath, content, corr, match_regex="test 2")
 
     def test_h(self):
         """Test h-file."""


### PR DESCRIPTION
If provided, it will only return TODOs that match the regex -- e.g.:

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/extract-todo (add-match-regex-flag●)
$ extract-todo --match-regex='test 2' tests/test_filetypes.py
tests/test_filetypes.py
  LINE 79:	test 2
  LINE 96:	test 2
  LINE 126:	test 2
  LINE 219:	test 2
```

If not provided, all TODOs are returned normally:

```
(.venv)
abramowi at Marcs-MacBook-Pro-3 in ~/Code/OpenSource/extract-todo (add-match-regex-flag●)
$ extract-todo tests/test_filetypes.py
tests/test_filetypes.py
  LINE 76:	test
  LINE 79:	test 2
  LINE 81:	test 3
  LINE 96:	test 2
  LINE 126:	test 2
  LINE 218:	test
  LINE 219:	test 2
```