### PR TITLE
Get all files from git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ PYPI_SERVER=pypi
 build:
 	@${PYTHON} -m build
 
+.PHONY: extract-todo
+extract-todo:
+	extract-todo
+
 .PHONY: test
 test: # Run tests
 	@${PYTHON} -m unittest -b

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ It prints the filename, line number and the TODO text. Example output:
       LINE 1:       test
       LINE 5:       test 2
 
+### Running on all relevant files in a directory
+
+Note that if you want to run this tool on all the supported files in your
+git-managed project, you can run `extract-todo` with no file arguments:
+
+    extract-todo
+
+If you want to limit it to searching certain files, you could do something like this:
+
+    extract-todo --filename-pattern='*.py' --filename-pattern='*.rb'
+
 ## Author and License
 
 Copyright (C) Jens Wilberg July 2021

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "GitPython"]
+requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=42", "wheel", "GitPython"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,8 @@ classifiers =
 	Operating System :: OS Independent
 	Environment :: Console
 	Intended Audience :: End Users/Desktop
+install_requires =
+        GitPython
 
 [options]
 package_dir = 

--- a/src/extract_todo/__main__.py
+++ b/src/extract_todo/__main__.py
@@ -20,13 +20,35 @@
 Currently only 'utf-8' file-encoding is supported.
 """
 import argparse
+from fnmatch import fnmatch
 from pathlib import Path
+from typing import List, Optional
+
+from git import Repo
 
 from extract_todo.__version__ import VERSION_STRING
 from extract_todo.extractor import Printer, extract_todos
+from .parser import ParserFactory
 
 __version__ = VERSION_STRING
 
+def get_default_glob_patterns():
+    supported_extensions = ParserFactory()._builders.keys()
+    default_glob_patterns = ["*" + extension for extension in supported_extensions]
+    return default_glob_patterns
+
+
+def get_files_from_git(glob_patterns: Optional[List[str]] = None):
+    if glob_patterns is None:
+        glob_patterns = get_default_glob_patterns()
+
+    files = []
+
+    for entry in Repo().commit().tree.traverse():
+        if any(fnmatch(entry.abspath, glob_pattern) for glob_pattern in glob_patterns):
+            files.append(Path(entry.path))
+
+    return files
 
 def main():
     """Main function as entry point."""
@@ -35,13 +57,23 @@ def main():
             the beginning of a single line comment. Supported files are LaTex\
             tex-files and Python-files. Currently only 'utf-8' file-encoding is\
             supported.")
-    parser.add_argument("files", metavar="file", type=Path, help="Path to file.", nargs='+')
+    parser.add_argument("files", metavar="file", type=Path,
+                        help="Path to file. If not given, search through all files in git", nargs='*')
     parser.add_argument('-v', '--version', action='version', version='%(prog)s {}'.format(__version__))
+    parser.add_argument('--filename-pattern', metavar="PATTERN", type=str, action="append",
+                        help="Limit search to filenames matching PATTERN. Can be specified multiple times. "
+                             "Used only if no files specified.")
     args = parser.parse_args()
     try:
-        todos = [str(Printer(extract_todos(fname))) for fname in args.files]
-        if todos:
-            print('\n'.join(todos))
+        if len(args.files) == 0:
+            files = get_files_from_git(args.filename_pattern)
+        else:
+           files = args.files
+
+        all_todos = [extract_todos(fname) for fname in files]
+        todos_str = [str(Printer(todos)) for todos in all_todos if todos]
+        if todos_str:
+            print('\n'.join(todos_str).strip())
         else:
             print("There are no TODOs.")
     except ValueError as e:


### PR DESCRIPTION
if no files specified

If you want to run this tool on all the supported files in your git-managed project, you can run `extract-todo` with no file arguments:

    extract-todo

If you want to limit it to searching certain files, you could do something like this:

    extract-todo --filename-pattern='*.py' --filename-pattern='*.rb'