### PR TITLE
Add `test_parser_factory.py`

### DIFF
--- a/tests/test_parser_factory.py
+++ b/tests/test_parser_factory.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 - 2021 Jens Wilberg
+#
+# This file is part of extract_todo.
+#
+# extract_todo is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# extract_todo is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with extract_todo.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for 'extract_todo'."""
+import sys
+from pathlib import Path
+
+from pyfakefs.fake_filesystem_unittest import TestCase
+
+# Import module to test
+sys.path.append(str(Path(__file__).resolve().parent.parent.joinpath("src")))
+from extract_todo.parser.parser_factory import ParserFactory, PythonParser, LatexParser, DefaultParser  # noqa: E402
+
+
+class Test(TestCase):
+    """Tests for 'extract_todo' package."""
+
+    def setUp(self):
+        """Set up test fixtures, if any."""
+        self.setUpPyfakefs()
+
+    def tearDown(self):
+        """Tear down test fixtures, if any."""
+        pass
+
+    def test_ParserFactory_create_PythonParser(self):
+        parser_factory = ParserFactory()
+        fpath = Path("test.py")
+        parser = parser_factory.create(fpath)
+        assert isinstance(parser, PythonParser)
+
+    def test_ParserFactory_create_LatexParser(self):
+        parser_factory = ParserFactory()
+        fpath = Path("test.tex")
+        parser = parser_factory.create(fpath)
+        assert isinstance(parser, LatexParser)
+
+    def test_ParserFactory_create_DefaultParser(self):
+        parser_factory = ParserFactory()
+        fpath = Path("test.cpp")
+        parser = parser_factory.create(fpath)
+        assert isinstance(parser, DefaultParser)
+
+    def test_ParserFactory_create_dir(self):
+        parser_factory = ParserFactory()
+        fpath = Path(".")
+        try:
+            parser_factory.create(fpath)
+        except ValueError as e:
+            assert str(e) == "'.' is a folder!"
+        else:
+            assert False, "Expected ValueError"
+
+    def test_ParserFactory_create_unsupported_file_type(self):
+        parser_factory = ParserFactory()
+        fpath = Path("test.zzz")
+        try:
+            parser_factory.create(fpath)
+        except ValueError as e:
+            assert str(e) == "'.zzz'-files are not supported!"
+        else:
+            assert False, "Expected ValueError"


### PR DESCRIPTION
Increases coverage of `parser_factory.py` from 88% to 100%.

```
(.venv)
abramowi at Marcs-MBP-3 in ~/Code/OpenSource/extract-todo (master●)
$ pytest --cov=. --cov-report=term-missing tests/test_parser_factory.py
================================== test session starts ===================================
platform darwin -- Python 3.10.8, pytest-8.1.1, pluggy-1.4.0
rootdir: /Users/abramowi/Code/OpenSource/extract-todo
configfile: pyproject.toml
plugins: cov-5.0.0, pyfakefs-5.3.5
collected 5 items

tests/test_parser_factory.py .....                                                 [100%]

---------- coverage: platform darwin, python 3.10.8-final-0 ----------
Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
...
src/extract_todo/parser/parser_factory.py      16      0   100%
...
-------------------------------------------------------------------------
TOTAL                                         193     97    50%

=================================== 5 passed in 0.08s ====================================
```